### PR TITLE
Fixed overlapping labels in Admin > Subscription Options

### DIFF
--- a/assets/css/wcsatt-write-panels.css
+++ b/assets/css/wcsatt-write-panels.css
@@ -115,6 +115,10 @@
 	float: left;
 }
 
+#wcsatt_data .subscription_scheme_data p._satt_subscription_details span.wrap label {
+	clear:both;
+}
+
 #wcsatt_data .subscription_scheme_data label {
 	margin: 0 0 0 -138px;
 	width: 118px;


### PR DESCRIPTION
There were overlapping labels of form fields within the panel for the Interval section