### PR TITLE
[2.0] Rename templates

### DIFF
--- a/includes/class-wcs-att-display-cart.php
+++ b/includes/class-wcs-att-display-cart.php
@@ -133,7 +133,7 @@ class WCS_ATT_Display_Cart {
 
 		$classes = $price_filter_exists ? array( 'overrides_exist' ) : array();
 
-		wc_get_template( 'cart/satt-cart-item-options.php', array(
+		wc_get_template( 'cart/cart-item-subscription-options.php', array(
 			'options'       => $options,
 			'cart_item_key' => $cart_item_key,
 			'classes'       => implode( ' ', $classes ),
@@ -203,7 +203,7 @@ class WCS_ATT_Display_Cart {
 				);
 			}
 
-			wc_get_template( 'cart/satt-cart-options.php', array(
+			wc_get_template( 'cart/cart-subscription-options.php', array(
 				'options' => $options,
 			), false, WCS_ATT()->plugin_path() . '/templates/' );
 		}

--- a/includes/class-wcs-att-display.php
+++ b/includes/class-wcs-att-display.php
@@ -178,7 +178,7 @@ class WCS_ATT_Display {
 
 			ob_start();
 
-			wc_get_template( 'single-product/satt-product-options.php', array(
+			wc_get_template( 'single-product/product-subscription-options.php', array(
 				'product'        => $product,
 				'product_id'     => $product_id,
 				'options'        => $options,

--- a/templates/cart/cart-item-subscription-options.php
+++ b/templates/cart/cart-item-subscription-options.php
@@ -2,13 +2,13 @@
 /**
  * Cart Item Subscription Options Template.
  *
- * Override this template by copying it to 'yourtheme/woocommerce/cart/satt-cart-item-options.php'.
+ * Override this template by copying it to 'yourtheme/woocommerce/cart/cart-item-subscription-options.php'.
  *
  * On occasion, this template file may need to be updated and you (the theme developer) will need to copy the new files to your theme to maintain compatibility.
  * We try to do this as little as possible, but it does happen.
  * When this occurs the version of the template file will be bumped and the readme will list any important changes.
  *
- * @version 1.2.0
+ * @version 2.0.0
  */
 
 // Exit if accessed directly.

--- a/templates/cart/cart-subscription-options.php
+++ b/templates/cart/cart-subscription-options.php
@@ -2,7 +2,7 @@
 /**
  * Cart Subscription Options Template.
  *
- * Override this template by copying it to 'yourtheme/woocommerce/cart/satt-cart-options.php'.
+ * Override this template by copying it to 'yourtheme/woocommerce/cart/cart-subscription-options.php'.
  *
  * On occasion, this template file may need to be updated and you (the theme developer) will need to copy the new files to your theme to maintain compatibility.
  * We try to do this as little as possible, but it does happen.

--- a/templates/single-product/product-subscription-options.php
+++ b/templates/single-product/product-subscription-options.php
@@ -2,13 +2,13 @@
 /**
  * Single-Product Subscription Options Template.
  *
- * Override this template by copying it to 'yourtheme/woocommerce/single-product/satt-product-options.php'.
+ * Override this template by copying it to 'yourtheme/woocommerce/single-product/product-subscription-options.php'.
  *
  * On occasion, this template file may need to be updated and you (the theme developer) will need to copy the new files to your theme to maintain compatibility.
  * We try to do this as little as possible, but it does happen.
  * When this occurs the version of the template file will be bumped and the readme will list any important changes.
  *
- * @version 1.2.0
+ * @version 2.0.0
  */
 
 // Exit if accessed directly.


### PR DESCRIPTION
Removes the `satt` prefix from template files. Classnames in markup (such as `satt-options-product`) are not touched yet.

In a potential merge of code with WCS, template locations in WCS could remain the same but the version will need to be bumped as class names will need to be changed.

Related: #148 