### PR TITLE
[2.0] Runtime meta handling

### DIFF
--- a/includes/product/class-wcs-att-product-schemes.php
+++ b/includes/product/class-wcs-att-product-schemes.php
@@ -44,7 +44,7 @@ class WCS_ATT_Product_Schemes {
 	 */
 	public static function has_forced_subscription_scheme( $product ) {
 
-		if ( '' === ( $forced = WCS_ATT_Product::get_product_property( $product, 'has_forced_subscription' ) ) && self::has_subscription_schemes( $product ) ) {
+		if ( '' === ( $forced = WCS_ATT_Product::get_runtime_meta( $product, 'has_forced_subscription' ) ) && self::has_subscription_schemes( $product ) ) {
 
 			$forced = WCS_ATT_Core_Compatibility::is_wc_version_gte_2_7() ? $product->get_meta( '_wcsatt_force_subscription', true ) : get_post_meta( WCS_ATT_Core_Compatibility::get_id( $product ), '_wcsatt_force_subscription', true );
 
@@ -59,7 +59,7 @@ class WCS_ATT_Product_Schemes {
 				}
 			}
 
-			WCS_ATT_Product::set_product_property( $product, 'has_forced_subscription', $forced );
+			WCS_ATT_Product::set_runtime_meta( $product, 'has_forced_subscription', $forced );
 		}
 
 		return 'yes' === $forced;
@@ -91,7 +91,7 @@ class WCS_ATT_Product_Schemes {
 	 */
 	public static function get_subscription_schemes( $product, $context = 'any' ) {
 
-		$schemes = WCS_ATT_Product::get_product_property( $product, 'subscription_schemes' );
+		$schemes = WCS_ATT_Product::get_runtime_meta( $product, 'subscription_schemes' );
 
 		// If not explicitly set on object, initialize with schemes defined at product-level.
 		if ( '' === $schemes ) {
@@ -128,7 +128,7 @@ class WCS_ATT_Product_Schemes {
 
 				$schemes = apply_filters( 'wcsatt_product_subscription_schemes', $schemes, $product );
 
-				WCS_ATT_Product::set_product_property( $product, 'subscription_schemes', $schemes );
+				WCS_ATT_Product::set_runtime_meta( $product, 'subscription_schemes', $schemes );
 			}
 		}
 
@@ -162,7 +162,7 @@ class WCS_ATT_Product_Schemes {
 	 */
 	public static function get_subscription_scheme( $product, $return = 'key', $scheme_key = '' ) {
 
-		$active_key   = WCS_ATT_Product::get_product_property( $product, 'active_subscription_scheme_key' );
+		$active_key   = WCS_ATT_Product::get_runtime_meta( $product, 'active_subscription_scheme_key' );
 		$search_key   = '' === $scheme_key ? $active_key : $scheme_key;
 		$schemes      = self::get_subscription_schemes( $product );
 		$found_scheme = null;
@@ -213,7 +213,7 @@ class WCS_ATT_Product_Schemes {
 	 */
 	public static function get_default_subscription_scheme( $product, $return = 'key' ) {
 
-		if ( '' === ( $default_scheme_key = WCS_ATT_Product::get_product_property( $product, 'default_subscription_scheme_key' ) ) ) {
+		if ( '' === ( $default_scheme_key = WCS_ATT_Product::get_runtime_meta( $product, 'default_subscription_scheme_key' ) ) ) {
 
 			$default_scheme     = null;
 			$default_scheme_key = false;
@@ -310,7 +310,7 @@ class WCS_ATT_Product_Schemes {
 	 * @return array
 	 */
 	public static function set_subscription_schemes( $product, $schemes ) {
-		WCS_ATT_Product::set_product_property( $product, 'subscription_schemes', $schemes );
+		WCS_ATT_Product::set_runtime_meta( $product, 'subscription_schemes', $schemes );
 	}
 
 	/**
@@ -335,30 +335,31 @@ class WCS_ATT_Product_Schemes {
 			$scheme_to_set = $schemes[ $key ];
 
 			// Set subscription scheme key.
-			WCS_ATT_Product::set_product_property( $product, 'active_subscription_scheme_key', $key );
+			WCS_ATT_Product::set_runtime_meta( $product, 'active_subscription_scheme_key', $key );
 
 			/*
-			 * Set subscription scheme details.
+			 * Set subscription scheme details. Required for WCS compatibility.
+			 * Later on, it might be better to grab these from the active 'WCS_ATT_Scheme' object instead.
 			 *
-			 * Note that prices are not set directly on object:
+			 * Note that prices are not set directly on objects:
 			 * The price strings of many product types depend on more than the values returned by the abstract class price getters.
 			 * If we are going to apply filters anyway, there's no need to permanently set raw prices here.
 			 */
-			WCS_ATT_Product::set_product_property( $product, 'subscription_period', $scheme_to_set[ 'subscription_period' ] );
-			WCS_ATT_Product::set_product_property( $product, 'subscription_period_interval', $scheme_to_set[ 'subscription_period_interval' ] );
-			WCS_ATT_Product::set_product_property( $product, 'subscription_length', $scheme_to_set[ 'subscription_length' ] );
+			WCS_ATT_Product::set_runtime_meta( $product, 'subscription_period', $scheme_to_set[ 'subscription_period' ] );
+			WCS_ATT_Product::set_runtime_meta( $product, 'subscription_period_interval', $scheme_to_set[ 'subscription_period_interval' ] );
+			WCS_ATT_Product::set_runtime_meta( $product, 'subscription_length', $scheme_to_set[ 'subscription_length' ] );
 
 			$scheme_set = true;
 
 		} elseif ( empty( $key ) ) {
 
 			// Reset subscription scheme key.
-			WCS_ATT_Product::set_product_property( $product, 'active_subscription_scheme_key', false === $key ? false : null );
+			WCS_ATT_Product::set_runtime_meta( $product, 'active_subscription_scheme_key', false === $key ? false : null );
 
-			// Reset subscription scheme details.
-			WCS_ATT_Product::set_product_property( $product, 'subscription_period', null );
-			WCS_ATT_Product::set_product_property( $product, 'subscription_period_interval', null );
-			WCS_ATT_Product::set_product_property( $product, 'subscription_length', null );
+			// Reset subscription scheme details. Required for WCS compatibility.
+			WCS_ATT_Product::set_runtime_meta( $product, 'subscription_period', null );
+			WCS_ATT_Product::set_runtime_meta( $product, 'subscription_period_interval', null );
+			WCS_ATT_Product::set_runtime_meta( $product, 'subscription_length', null );
 
 			$scheme_set = true;
 		}
@@ -382,7 +383,7 @@ class WCS_ATT_Product_Schemes {
 	 * @param  boolean     $is_forced_subscription  Value.
 	 */
 	public static function set_forced_subscription_scheme( $product, $is_forced_subscription ) {
-		WCS_ATT_Product::set_product_property( $product, 'has_forced_subscription', $is_forced_subscription ? 'yes' : 'no' );
+		WCS_ATT_Product::set_runtime_meta( $product, 'has_forced_subscription', $is_forced_subscription ? 'yes' : 'no' );
 	}
 
 	/*

--- a/tests/framework/helpers/class-wcs-att-test-helpers-product.php
+++ b/tests/framework/helpers/class-wcs-att-test-helpers-product.php
@@ -50,7 +50,7 @@ class WCS_ATT_Test_Helpers_Product {
 					'subscription_length'          => 5
 				),
 
-				1=> array(
+				1 => array(
 					'subscription_period_interval' => 2,
 					'subscription_period'          => 'month',
 					'subscription_length'          => 10

--- a/tests/unit/test-wcs-att-product.php
+++ b/tests/unit/test-wcs-att-product.php
@@ -27,11 +27,62 @@ class WCS_ATT_Product_Tests extends WCS_ATT_Test_Case {
 		// The product should not be seen as a subscription just yet.
 		$this->assertFalse( WCS_ATT_Product::is_subscription( $product ) );
 
-		$result = WCS_ATT_Product_Schemes::set_subscription_scheme( $product, '1_month_5' );
+		WCS_ATT_Product_Schemes::set_subscription_scheme( $product, '1_month_5' );
 
 		// But now it should...
 		$this->assertTrue( WCS_ATT_Product::is_subscription( $product ) );
 		$this->assertTrue( WC_Subscriptions_Product::is_subscription( $product ) );
+
+		WCS_ATT_Test_Helpers_Product::delete_simple_satt_product( $product );
+	}
+
+	/**
+	 * @covers WCS_ATT_Product_Schemes::set_runtime_meta
+	 * @covers WCS_ATT_Product_Schemes::get_runtime_meta
+	 *
+	 * @since 2.0.0
+	 */
+	public function test_get_set_runtime_meta() {
+
+		$product = WCS_ATT_Test_Helpers_Product::create_simple_satt_product();
+
+		// Ensure runtime meta is created on the object correctly.
+		WCS_ATT_Product_Schemes::set_subscription_scheme( $product, '1_month_5' );
+		$this->assertNotEmpty( $product->get_meta( '_satt_data', true ) );
+		$this->assertEquals( 2, sizeof( WCS_ATT_Product::get_runtime_meta( $product, 'subscription_schemes' ) ) );
+
+		$this->assertEquals( 'month', WCS_ATT_Product::get_runtime_meta( $product, 'subscription_period' ) );
+		$this->assertEquals( '1', WCS_ATT_Product::get_runtime_meta( $product, 'subscription_period_interval' ) );
+		$this->assertEquals( '5', WCS_ATT_Product::get_runtime_meta( $product, 'subscription_length' ) );
+
+		// Keys persisted by WCS in the DB should be retrievable using the WC core meta getter as well.
+		$this->assertEquals( 'month', $product->get_meta( '_subscription_period', true ) );
+		$this->assertEquals( '1', $product->get_meta( '_subscription_period_interval', true ) );
+		$this->assertEquals( '5', $product->get_meta( '_subscription_length', true ) );
+
+		WCS_ATT_Test_Helpers_Product::delete_simple_satt_product( $product );
+	}
+
+	/**
+	 * @covers WCS_ATT_Product_Schemes::delete_runtime_meta
+	 *
+	 * @since 2.0.0
+	 */
+	public function test_delete_runtime_meta() {
+
+		$product = WCS_ATT_Test_Helpers_Product::create_simple_satt_product();
+
+		// Set a scheme on the object.
+		WCS_ATT_Product_Schemes::set_subscription_scheme( $product, '1_month_5' );
+
+		// Save.
+		$product->save();
+
+		// Runtime meta shouldn't be there anymore.
+		$this->assertEmpty( $product->get_meta( '_satt_data', true ) );
+		$this->assertEmpty( $product->get_meta( '_subscription_period', true ) );
+		$this->assertEmpty( $product->get_meta( '_subscription_period_interval', true ) );
+		$this->assertEmpty( $product->get_meta( '_subscription_length', true ) );
 
 		WCS_ATT_Test_Helpers_Product::delete_simple_satt_product( $product );
 	}


### PR DESCRIPTION
@thenbrent you might want to have a quick look at this one as it's right at the core of SATT.

Checklist:

1. None of the [meta](https://github.com/Prospress/woocommerce-subscribe-all-the-things/compare/2.0...issue-163#diff-1f9b8d9552b9a679b925a590e66a072bR33) currently written to the DB by WCS should be persisted when saving a non-subscription-type product. See [this](https://github.com/Prospress/woocommerce-subscribe-all-the-things/compare/2.0...issue-163#diff-1f9b8d9552b9a679b925a590e66a072bR142).
2. For posterity, none of those meta fields are needed by WCS 3.0 (?) -- subscription details can be retrieved from scheme objects, which are created at runtime and saved in "runtime meta" territory. See `WCS_ATT_Product_Schemes::get_subscription_schemes`.
3. All "runtime data" has been consolidated under a single WC meta field, `_satt_data`, which is deleted when a product object is saved. See `WCS_ATT_Product::get/set_runtime_meta`.
4. One implication of this is that **runtime data is lost when a product is saved**, along with the subscription state of a product object. I am not sure if this is a bad idea -- I cannot imagine any scenario where `WC_Product::save` would be called that requires subscription state to be maintained after saving. (Need to think/check further.)

(4) is probably the most "critical" item in this list. If we don't want this behavior, then we will need to revise the way we associate subscription scheme/state data with product instances, and probably abandon the "runtime meta" approach.