### PR TITLE
Scheme Switching for Core Types

### DIFF
--- a/includes/class-wcs-att-cart.php
+++ b/includes/class-wcs-att-cart.php
@@ -224,7 +224,6 @@ class WCS_ATT_Cart {
 		return $cart_item;
 	}
 
-
 	/**
 	 * Load saved session data of cart items that can be pruchased on a recurring basis.
 	 *
@@ -351,6 +350,16 @@ class WCS_ATT_Cart {
 						WCS_ATT_Product_Schemes::set_forced_subscription_scheme( $cart->cart_contents[ $cart_item_key ][ 'data' ], true );
 					}
 				}
+
+				/**
+				 * 'wcsatt_applied_cart_item_subscription_scheme' action.
+				 *
+				 * @since  2.1.0
+				 *
+				 * @param  array   $cart_item
+				 * @param  string  $cart_item_key
+				 */
+				do_action( 'wcsatt_applied_cart_item_subscription_scheme', $cart_item, $cart_item_key );
 			}
 		}
 	}

--- a/includes/class-wcs-att-cart.php
+++ b/includes/class-wcs-att-cart.php
@@ -32,17 +32,17 @@ class WCS_ATT_Cart {
 	 */
 	private static function add_hooks() {
 
-		// Add scheme data to cart items that can be pruchased on a recurring basis.
+		// Add scheme data to cart items that can be purchased on a recurring basis.
 		add_filter( 'woocommerce_add_cart_item_data', array( __CLASS__, 'add_cart_item_data' ), 10, 3 );
 
-		// Load saved session data of cart items that can be pruchased on a recurring basis.
+		// Load saved session data of cart items that can be purchased on a recurring basis.
 		add_filter( 'woocommerce_get_cart_item_from_session', array( __CLASS__, 'load_cart_item_data_from_session' ), 5, 2 );
 
 		// Inspect product-level/cart-level session data and apply subscription schemes to cart items as needed.
 		add_action( 'woocommerce_cart_loaded_from_session', array( __CLASS__, 'apply_subscription_schemes' ), 5 );
 
 		// Inspect product-level/cart-level session data on add-to-cart and apply subscription schemes to cart items as needed. Then, recalculate totals.
-		add_action( 'woocommerce_add_to_cart', array( __CLASS__, 'apply_subscription_schemes_on_add_to_cart' ), 1000, 6 );
+		add_action( 'woocommerce_add_to_cart', array( __CLASS__, 'apply_subscription_schemes_on_add_to_cart' ), 19, 6 );
 
 		// Update the subscription scheme saved on a cart item when chosing a new option.
 		add_filter( 'woocommerce_update_cart_action_cart_updated', array( __CLASS__, 'update_cart_item_data' ), 10 );
@@ -413,10 +413,7 @@ class WCS_ATT_Cart {
 	 * @return void
 	 */
 	public static function apply_subscription_schemes_on_add_to_cart( $item_key, $product_id, $quantity, $variation_id, $variation, $item_data ) {
-
 		self::apply_subscription_schemes( WC()->cart );
-
-		WC()->cart->calculate_totals();
 	}
 
 	/**

--- a/includes/class-wcs-att-switcher.php
+++ b/includes/class-wcs-att-switcher.php
@@ -1,0 +1,255 @@
+<?php
+/**
+ * WCS_ATT_Switcher class
+ *
+ * @author   SomewhereWarm <info@somewherewarm.gr>
+ * @package  WooCommerce Subscribe All the Things
+ * @since    2.1.0
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Handles scheme switching for SATT items.
+ *
+ * @class    WCS_ATT_Switcher
+ * @version  2.1.0
+ */
+class WCS_ATT_Switcher {
+
+	/**
+	 * Initialization.
+	 */
+	public static function init() {
+		self::add_hooks();
+	}
+
+	/**
+	 * Hook-in.
+	 */
+	private static function add_hooks() {
+
+		// Allow scheme switching for SATT products with more than 1 scheme.
+		add_filter( 'wcs_is_product_switchable', array( __CLASS__, 'is_product_switchable' ), 10, 2 );
+
+		// Disable one-time purchases when switching.
+		add_filter( 'wcsatt_force_subscription', array( __CLASS__, 'force_subscription' ), 10, 2 );
+
+		// Allow WCS to recognize any supported product as a subscription when validating a switch: Add filter.
+		add_filter( 'woocommerce_add_to_cart_validation', array( __CLASS__, 'add_is_subscription_filter' ), 9 );
+
+		// Allow WCS to recognize any supported product as a subscription when validating a switch: Remove filter.
+		add_filter( 'woocommerce_add_to_cart_validation', array( __CLASS__, 'remove_is_subscription_filter' ), 11 );
+
+		// Make WCS see products with a switched scheme as non-identical ones.
+		add_filter( 'woocommerce_subscriptions_switch_is_identical_product', array( __CLASS__, 'is_identical_product' ), 10, 6 );
+
+		// Modify cart item being switched.
+		add_action( 'wcsatt_applied_cart_item_subscription_scheme', array( __CLASS__, 'edit_switched_cart_item' ), 10, 2 );
+	}
+
+	/**
+	 * True if switching is in progress.
+	 *
+	 * @return boolean
+	 */
+	public static function switching() {
+		return isset( $_GET[ 'switch-subscription' ] ) && isset( $_GET[ 'item' ] );
+	}
+
+	/**
+	 * True if a subscribed product scheme/configuration is being switched.
+	 *
+	 * @param  WC_Product  $product_switched
+	 * @return boolean
+	 */
+	public static function switching_product( $product_switched ) {
+
+		$switching = false;
+
+		if ( self::switching() ) {
+
+			if ( is_product() ) {
+
+				global $product;
+
+				if ( $product->get_id() === $product_switched->get_id() ) {
+					$switching = true;
+				}
+
+			} elseif ( ! empty( $_REQUEST[ 'add-to-cart' ] ) && is_numeric( $_REQUEST[ 'add-to-cart' ] ) ) {
+
+				$product_id = apply_filters( 'woocommerce_add_to_cart_product_id', absint( $_REQUEST[ 'add-to-cart' ] ) );
+
+				if ( isset( $_REQUEST[ 'convert_to_sub_' . $product_id ] ) ) {
+					$posted    = wc_clean( $_REQUEST[ 'convert_to_sub_' . $product_id ] );
+					$switching = ! empty( $posted );
+				}
+			}
+		}
+
+		return $switching;
+	}
+
+	/*
+	|--------------------------------------------------------------------------
+	| Hooks
+	|--------------------------------------------------------------------------
+	*/
+
+	/**
+	 * Allow scheme switching for SATT products with more than 1 subscription scheme.
+	 *
+	 * @param  boolean     $is_switchable
+	 * @param  WC_Product  $product
+	 * @return boolean
+	 */
+	public static function is_product_switchable( $is_switchable, $product ) {
+
+		if ( ! $is_switchable ) {
+
+			$subscription_schemes = WCS_ATT_Product_Schemes::get_subscription_schemes( $product );
+			$is_switchable        = sizeof( $subscription_schemes ) > 1;
+		}
+
+		return $is_switchable;
+	}
+
+	/**
+	 * Disable one-time purchases when switching.
+	 *
+	 * @param  boolean     $is_forced
+	 * @param  WC_Product  $product
+	 * @return boolean
+	 */
+	public static function force_subscription( $is_forced, $product ) {
+
+		if ( ! $is_forced && self::switching() ) {
+			$is_forced = self::switching_product( $product );
+		}
+
+		return $is_forced;
+	}
+
+	/**
+	 * Allow WCS to recognize any supported product as a subscription when validating a switch: Add filter.
+	 *
+	 * @param  boolean  $is_valid
+	 * @return boolean
+	 */
+	public static function add_is_subscription_filter( $is_valid ) {
+
+		if ( self::switching() ) {
+			add_filter( 'woocommerce_is_subscription', array( __CLASS__, 'filter_is_subscription' ), 11, 3 );
+		}
+
+		return $is_valid;
+	}
+
+	/**
+	 * Allow WCS to recognize any supported product as a subscription when validating a switch: Remove filter.
+	 *
+	 * @param  boolean  $is_valid
+	 * @return boolean
+	 */
+	public static function remove_is_subscription_filter( $is_valid ) {
+
+		if ( self::switching() ) {
+			remove_filter( 'woocommerce_is_subscription', array( __CLASS__, 'filter_is_subscription' ), 11, 3 );
+		}
+
+		return $is_valid;
+	}
+
+	/**
+	 * Hooks onto 'woocommerce_is_subscription' to trick WCS into thinking it is dealing with a subscription-type product when switching.
+	 *
+	 * @param  boolean     $is
+	 * @param  int         $product_id
+	 * @param  WC_Product  $product
+	 * @return boolean
+	 */
+	public static function filter_is_subscription( $is, $product_id, $product ) {
+
+		if ( self::switching() ) {
+
+			if ( ! is_a( $product, 'WC_Product' ) ) {
+				$product = wc_get_product( $product_id );
+			}
+
+			if ( ! $product ) {
+				return $is;
+			}
+
+			if ( self::switching_product( $product ) && WCS_ATT_Product_Schemes::has_subscription_schemes( $product ) ) {
+				$is = true;
+			}
+		}
+
+		return $is;
+	}
+
+	/**
+	 * Make WCS see products with a switched scheme as non-identical ones.
+	 *
+	 * @param  boolean        $is_identical
+	 * @param  int            $product_id
+	 * @param  int            $quantity
+	 * @param  int            $variation_id
+	 * @param  WC_Order       $subscription
+	 * @param  WC_Order_Item  $item
+	 * @return boolean
+	 */
+	public static function is_identical_product( $is_identical, $product_id, $quantity, $variation_id, $subscription, $item ) {
+
+		if ( $is_identical ) {
+
+			if ( isset( $_REQUEST[ 'convert_to_sub_' . $product_id ] ) ) {
+
+				$new_subscription_scheme_key = wc_clean( $_POST[ 'convert_to_sub_' . $product_id ] );
+				$old_subscription_scheme_key = WCS_ATT_Order::get_subscription_scheme( $item );
+
+				if ( $new_subscription_scheme_key && $new_subscription_scheme_key !== $old_subscription_scheme_key ) {
+					$is_identical = false;
+				}
+			}
+		}
+
+		return $is_identical;
+	}
+
+	/**
+	 * Modify cart item being switched.
+	 *
+	 * @param  array   $cart_item
+	 * @param  string  $cart_item_key
+	 * @return void
+	 */
+	public static function edit_switched_cart_item( $cart_item, $cart_item_key ) {
+
+		/*
+		 * Keep only the applied scheme when switching.
+		 * If we don't do this, then multiple scheme options will show up next to the cart item.
+		 */
+		if ( isset( $cart_item[ 'subscription_switch' ] ) ) {
+
+			$applied_scheme = WCS_ATT_Product_Schemes::get_subscription_scheme( $cart_item[ 'data' ] );
+			$schemes        = array();
+
+			foreach ( WCS_ATT_Cart::get_subscription_schemes( $cart_item ) as $scheme_key => $scheme ) {
+
+				if ( $scheme_key === $applied_scheme ) {
+					$schemes[ $scheme_key ] = $scheme;
+				}
+			}
+
+			WCS_ATT_Product_Schemes::set_subscription_schemes( WC()->cart->cart_contents[ $cart_item_key ][ 'data' ], $schemes );
+			WCS_ATT_Product_Schemes::set_forced_subscription_scheme( WC()->cart->cart_contents[ $cart_item_key ][ 'data' ], true );
+		}
+	}
+}
+
+WCS_ATT_Switcher::init();

--- a/includes/product/class-wcs-att-product-schemes.php
+++ b/includes/product/class-wcs-att-product-schemes.php
@@ -57,7 +57,7 @@ class WCS_ATT_Product_Schemes {
 			WCS_ATT_Product::set_runtime_meta( $product, 'has_forced_subscription', $forced );
 		}
 
-		return 'yes' === $forced;
+		return apply_filters( 'wcsatt_force_subscription', 'yes' === $forced, $product );
 	}
 
 	/**

--- a/woocommerce-subscribe-all-the-things.php
+++ b/woocommerce-subscribe-all-the-things.php
@@ -146,6 +146,7 @@ class WCS_ATT {
 		require_once( 'includes/class-wcs-att-cart.php' );
 		require_once( 'includes/class-wcs-att-display.php' );
 		require_once( 'includes/class-wcs-att-order.php' );
+		require_once( 'includes/class-wcs-att-switcher.php' );
 
 		// Legacy stuff.
 		require_once( 'includes/legacy/class-wcs-att-schemes.php' );


### PR DESCRIPTION
Closes #233 

Ran some simple test cases with Simple + Variable products, seems to work. 

I'd love to have an extra confirmation, though, preferably from someone who knows how things can break in WCS. I saw some open issues related to switching in https://github.com/Prospress/woocommerce-subscriptions/issues/2452 .

Since we haven't added syncing to SATT yet, I didn't consider testing anything beyond confirming that schemes + attributes can be switched successfully. So I haven't done any testing to confirm that proration works as intended here. Not sure if I should.

Note that this enables switching for all products with subscription schemes via `wcs_is_product_switchable`. Should we have a global option to disable this somewhere -- perhaps around here: https://cl.ly/450l2E392o01 ?

Ideally I think switching should be enabled/disabled at product level, though. SATT might be a good opportunity to deviate from WCS 1/2 if it's something we _want_ for WCS 3+.