### PR TITLE
When resubscribing remove all scheme data

### DIFF
--- a/includes/class-wcs-att-cart.php
+++ b/includes/class-wcs-att-cart.php
@@ -515,8 +515,8 @@ class WCS_ATT_Cart {
 			$scheme_to_apply = self::get_subscription_scheme( $cart_item );
 			$applied_scheme  = WCS_ATT_Product_Schemes::get_subscription_scheme( $cart_item[ 'data' ] );
 
-			// Handle mismatch. Remember that when renewing we are deleting all scheme data from the object and letting WCS handle everything.
-			if ( $scheme_to_apply !== $applied_scheme && ! isset( $cart_item[ 'subscription_renewal' ] ) ) {
+			// Handle mismatch. Remember that when renewing or resubscribing we are deleting all scheme data from the object and letting WCS handle everything.
+			if ( $scheme_to_apply !== $applied_scheme && ! isset( $cart_item[ 'subscription_renewal' ] ) && ! isset( $cart_item[ 'subscription_resubscribe' ] ) ) {
 
 				$available_schemes  = WCS_ATT_Product_Schemes::get_subscription_schemes( $cart_item[ 'data' ] );
 				$has_forced_schemes = WCS_ATT_Product_Schemes::has_forced_subscription_scheme( $cart_item[ 'data' ] );


### PR DESCRIPTION
Ticket on our side: https://secure.helpscout.net/conversation/626484821/15046/

The steps I took to replicate: 

1. Create a regular simple product [with no subscription options](https://cloudup.com/cTrfyGyaInP)
2. From the **WooCommerce > Subscription** table click "Add New"
3. Create a new subscription adding the simple product as a line item and selecting your user as the customer.
4. Create a parent order or process a renewal. This order needs to have a completed/processing status - we need at least 1 completed payment. 
5. Now cancel the subscription. 
6. From your **My Account > View subscription** page click resubscribe.
7. You should get an error which looks like this: https://cloudup.com/cY2EoHGMiPp

I've done a little bit of digging and I suspect the issue is that because the subscription was created manually via admin, the `_wcsatt_scheme` line item meta doesn't exist. Because that meta doesn't exist, [`check_applied_subscription_schemes()`](https://github.com/Prospress/woocommerce-subscribe-all-the-things/blob/2.1.1/includes/class-wcs-att-cart.php#L511) cannot add the product to the cart with a subscription scheme.

I'm not sure if this fix is correct but it fixes the error 😆 and matches the same behaviour when renewing via the cart. 