### PR TITLE
Resolve conflict between NYP variations and SATT. 

### DIFF
--- a/assets/css/wcs-att-frontend.css
+++ b/assets/css/wcs-att-frontend.css
@@ -42,6 +42,10 @@ ul.wcsatt-options-product {
 	display: inline;
 }
 
+.woocommerce-variation-add-to-cart .wcsatt-options-wrapper {
+	display: none;
+}
+
 /* Cart */
 
 ul.wcsatt-options-cart {

--- a/assets/js/wcs-att-single-add-to-cart.js
+++ b/assets/js/wcs-att-single-add-to-cart.js
@@ -91,6 +91,9 @@
 			variation_found: function( event, variation ) {
 				this.variation = variation;
 				this.initialize( { $el_options: this.$el.find( '.wcsatt-options-wrapper' ) } );
+
+
+				this.$el.find( '.wcsatt-options-wrapper' ).slideDown();
 			},
 
 			variation_selected: function() {
@@ -98,6 +101,9 @@
 			},
 
 			reset_schemes: function() {
+
+				this.$el.find( '.wcsatt-options-wrapper' ).slideUp();
+
 				this.variation = false;
 				this.model.set_schemes( {} );
 				this.model.set_active_scheme( false );
@@ -122,7 +128,6 @@
 			},
 
 			initialize: function( options ) {
-
 				this.$el_options = options.$el_options;
 
 				this.model.set_schemes( this.find_schemes() );
@@ -736,6 +741,13 @@
 	$( '.composite_form .composite_data' ).each( function() {
 		$( this ).on( 'wc-composite-initializing', function( event, composite ) {
 			new CP_Integration( composite );
+		} );
+	} );
+
+	// Hook into Mix and Match.
+	$( '.mnm_form .mnm_cart' ).each( function() {
+		$( this ).on( 'wc-mnm-initialized', function( event, mnm ) {
+			new MNM_Integration( bundle );
 		} );
 	} );
 

--- a/includes/display/class-wcs-att-display-product.php
+++ b/includes/display/class-wcs-att-display-product.php
@@ -45,8 +45,6 @@ class WCS_ATT_Display_Product {
 		add_filter( 'woocommerce_product_add_to_cart_url', array( __CLASS__, 'add_to_cart_url' ), 10, 2 );
 		add_filter( 'woocommerce_product_supports', array( __CLASS__, 'supports_ajax_add_to_cart' ), 10, 3 );
 
-		// Replace plain variation price html with subscription options template.
-		add_filter( 'woocommerce_available_variation', array( __CLASS__, 'add_subscription_options_to_variation_data' ), 0, 3 );
 	}
 
 	/**
@@ -59,13 +57,6 @@ class WCS_ATT_Display_Product {
 	public static function get_subscription_options_content( $product, $parent_product = null ) {
 
 		if ( ! WCS_ATT_Product::supports_feature( $product, 'subscription_scheme_options_product_single' ) ) {
-			return '';
-		}
-
-		/*
-		 * Subscription options for variable products are embedded inside the variation data 'price_html' field and updated by the core variations script.
-		 */
-		if ( $product->is_type( 'variable' ) ) {
 			return '';
 		}
 


### PR DESCRIPTION
Displays both NYP price input and SATT options (first pass)

Problem:

If a variable product has an NYP variation, then the SATT options do not display:

![image](https://user-images.githubusercontent.com/507025/47272670-b1166380-d54e-11e8-8699-a267c258f6a0.png)

This is because NYP also filters `woocommerce_available_variation` to change the `price_html` [here](https://github.com/woocommerce/woocommerce-name-your-price/blob/master/includes/class-wc-name-your-price-display.php#L408).

By avoiding this filter and displaying the SATT scheme options in the same before add to cart button location, the two are able to display simultaneously.

![image](https://user-images.githubusercontent.com/507025/47272729-77922800-d54f-11e8-953d-e1ca196016f2.png)

Given that current the SATT options are not variation-specific, it seems unnecessary to attach them to each variation, but I may not understand that reasoning yet. 



