### PR TITLE
Variable nyp compat 2

### DIFF
--- a/assets/js/wcs-att-single-add-to-cart.js
+++ b/assets/js/wcs-att-single-add-to-cart.js
@@ -90,6 +90,7 @@
 
 			variation_found: function( event, variation ) {
 				this.variation = variation;
+				this.$el.find( '.single_variation' ).append( variation.satt_html );
 				this.initialize( { $el_options: this.$el.find( '.wcsatt-options-wrapper' ) } );
 			},
 

--- a/assets/js/wcs-att-single-add-to-cart.js
+++ b/assets/js/wcs-att-single-add-to-cart.js
@@ -90,7 +90,7 @@
 
 			variation_found: function( event, variation ) {
 				this.variation = variation;
-				this.$el.find( '.single_variation' ).append( variation.satt_html );
+				this.$el.find( '.wcsatt-single-variation' ).html( variation.satt_html ).show();
 				this.initialize( { $el_options: this.$el.find( '.wcsatt-options-wrapper' ) } );
 			},
 
@@ -99,6 +99,7 @@
 			},
 
 			reset_schemes: function() {
+				this.$el.find( '.wcsatt-single-variation' ).hide();
 				this.variation = false;
 				this.model.set_schemes( {} );
 				this.model.set_active_scheme( false );

--- a/includes/display/class-wcs-att-display-product.php
+++ b/includes/display/class-wcs-att-display-product.php
@@ -34,6 +34,7 @@ class WCS_ATT_Display_Product {
 
 		// Display subscription options in the single-product template.
 		add_action( 'woocommerce_before_add_to_cart_button', array( __CLASS__, 'show_subscription_options' ), 100 );
+		add_action( 'woocommerce_single_variation', array( __CLASS__, 'show_subscription_options_for_variations' ), 15 ); 
 
 		// Changes the single-product add-to-cart button text when a product with the force subscription is set.
 		add_filter( 'woocommerce_product_single_add_to_cart_text', array( __CLASS__, 'single_add_to_cart_text' ), 10, 2 );
@@ -250,6 +251,17 @@ class WCS_ATT_Display_Product {
 		global $product;
 		echo self::get_subscription_options_content( $product );
 	}
+
+
+	/**
+	 * Holder for single-product options.
+	 *
+	 * @return void
+	 */
+	public static function show_subscription_options_for_variations() {
+		echo '<div class="wcsatt-single-variation" style="display: none"></div>';
+	}
+
 
 	/**
 	 * Overrides the single-product add-to-cart button text with "Sign up".

--- a/includes/display/class-wcs-att-display-product.php
+++ b/includes/display/class-wcs-att-display-product.php
@@ -121,7 +121,7 @@ class WCS_ATT_Display_Product {
 				}
 			}
 
-			$sub_price_html = WCS_ATT_Product_Prices::get_price_html( $product, $subscription_scheme->get_key(), $sub_price_html_args );
+			$sub_price_html = WCS_ATT_Product_Prices::get_price_html( $product, $subscription_scheme->get_key(), apply_filters( 'wcsatt_subscription_price_html_args', $sub_price_html_args, $subscription_scheme, $product ) );
 			$sub_price_html = false === $sub_price_html_args[ 'subscription_price' ] ? '<span class="subscription-details">' . $sub_price_html . '</span>' : $sub_price_html;
 			$sub_price_html = '<span class="' . $price_class . ' subscription-price">' . $sub_price_html . '</span>';
 

--- a/includes/display/class-wcs-att-display-product.php
+++ b/includes/display/class-wcs-att-display-product.php
@@ -195,6 +195,8 @@ class WCS_ATT_Display_Product {
 				$is_single_scheme_forced_subscription = $force_subscription && sizeof( $subscription_schemes ) === 1;
 				$has_equal_variation_prices           = '' === $variation_data[ 'price_html' ];
 
+				$variation_data[ 'satt_html' ] = $subscription_options_content;
+
 				/*
 				 * When should we keep the existing price string?
 				 *
@@ -203,7 +205,7 @@ class WCS_ATT_Display_Product {
 				 */
 				if ( $is_single_scheme_forced_subscription || ( false === $price_filter_exists && $has_equal_variation_prices ) ) {
 
-					$variation_data[ 'price_html' ] = $variation_data[ 'price_html' ] . $subscription_options_content;
+					$variation_data[ 'price_html' ] = $variation_data[ 'price_html' ];
 
 				} else {
 
@@ -224,7 +226,7 @@ class WCS_ATT_Display_Product {
 					WCS_ATT_Product_Schemes::set_subscription_scheme( $variation_product, false );
 
 					// Get the price string :)
-					$variation_data[ 'price_html' ] = '<span class="price">' . $variation_product->get_price_html() . '</span>' . $subscription_options_content;
+					$variation_data[ 'price_html' ] = '<span class="price">' . $variation_product->get_price_html() . '</span>';
 
 					// Un-do.
 					WCS_ATT_Product_Schemes::set_subscription_scheme( $variation_product, $active_scheme_key );


### PR DESCRIPTION
Move the SATT options output to `woocommerce_single_variation hook` hook, but still dynamically load the content on the `variation_found` JS trigger... fixes display order with NYP.

Filter subscription price string args to allow NYP to manipulate strings.

Closes #371