### PR TITLE
Fixed bug with multiple mini cart calls

### DIFF
--- a/includes/display/class-wcs-att-display-cart.php
+++ b/includes/display/class-wcs-att-display-cart.php
@@ -65,7 +65,7 @@ class WCS_ATT_Display_Cart {
 			return $price;
 		}
 
-		$is_mini_cart = did_action( 'woocommerce_before_mini_cart' ) && ! did_action( 'woocommerce_after_mini_cart' );
+        $is_mini_cart = did_action( 'woocommerce_before_mini_cart' ) !== did_action( 'woocommerce_after_mini_cart' );
 
 		// Only show options in cart.
 		if ( ! is_cart() || $is_mini_cart ) {


### PR DESCRIPTION
The WordPress function did_action($tag) returns the number of times that the respective action or filter has been run to completion in the current request. 

For some mini carts, the actions 'woocommerce_before_mini_cart' and 'woocommerce_after_mini_cart' get called for every single product in the cart (e.g., in the theme The7). 

By simply checking that the number of 'woocommerce_before_mini_cart' actions is different than the number of 'woocommerce_after_mini_cart' actions, the value of $is_mini_cart becomes more reliable (instead of '!==', also '>' can be used). 