### PR TITLE
Modify 'wcsatt_restore_subscription_scheme_from_subscription_args' params

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** WooCommerce Subscribe All the Things ***
 
-2019.01.23 - version 2.1.5
+2019.02.05 - version 2.1.5
+* Important - Modified 'wcsatt_restore_subscription_scheme_from_subscription_args' filter params.
 * Fix - Child Bundle/Composite cart item prices not aggregated when: 1) choosing the one-off option; and 2) the container product has a blank base/static price.
 * Fix - Fatal error when adding carts to subscriptions under WC 3.5+.
 

--- a/includes/class-wcs-att-order.php
+++ b/includes/class-wcs-att-order.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Order hooks for saving/restoring the subscription state of a product to/from order item data.
  *
  * @class    WCS_ATT_Order
- * @version  2.1.2
+ * @version  2.1.5
  */
 class WCS_ATT_Order {
 
@@ -76,7 +76,7 @@ class WCS_ATT_Order {
 		} else {
 
 			$default_args = array(
-				'subscription'       => false,
+				'order'              => false,
 				'match_subscription' => false,
 				'match_args'         => array(
 					'next_payment'      => false,
@@ -97,14 +97,14 @@ class WCS_ATT_Order {
 			 */
 			$args = apply_filters( 'wcsatt_restore_subscription_scheme_from_subscription_args', wp_parse_args( $args, $default_args ), $order_item );
 
-			if ( $args[ 'match_subscription' ] && wcs_is_subscription( $args[ 'subscription' ] ) ) {
+			if ( $args[ 'match_subscription' ] && wcs_is_subscription( $args[ 'match_subscription' ] ) ) {
 
 				$product = $order_item->get_product();
 
 				if ( $product && ( $subscription_schemes = WCS_ATT_Product_Schemes::get_subscription_schemes( $product ) ) ) {
 
 					foreach ( $subscription_schemes as $subscription_scheme ) {
-						if ( $subscription_scheme->matches_subscription( $args[ 'subscription' ], $args[ 'match_args' ] ) ) {
+						if ( $subscription_scheme->matches_subscription( $args[ 'match_subscription' ], $args[ 'match_args' ] ) ) {
 							$scheme_key = $subscription_scheme->get_key();
 						}
 					}
@@ -132,8 +132,7 @@ class WCS_ATT_Order {
 	public static function restore_cart_item_from_order_item( $cart_item, $order_item, $order ) {
 
 		$scheme_key = self::get_subscription_scheme( $order_item, array(
-			'subscription'       => $order,
-			'match_subscription' => true
+			'order' => $order
 		) );
 
 		if ( null !== $scheme_key ) {

--- a/languages/woocommerce-subscribe-all-the-things.pot
+++ b/languages/woocommerce-subscribe-all-the-things.pot
@@ -2,10 +2,10 @@
 # This file is distributed under the GNU General Public License v3.0.
 msgid ""
 msgstr ""
-"Project-Id-Version: WooCommerce Subscribe All the Things 2.1.4\n"
+"Project-Id-Version: WooCommerce Subscribe All the Things 2.1.5-dev\n"
 "Report-Msgid-Bugs-To: "
 "https://github.com/Prospress/woocommerce-subscribe-all-the-things/issues\n"
-"POT-Creation-Date: 2019-01-23 11:53:35+00:00\n"
+"POT-Creation-Date: 2019-02-05 12:36:21+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"


### PR DESCRIPTION
...to make its usage clearer.

The `order` key may sometimes pass a vanilla WC order (when paying for a parent/initial order), and sometimes a subscription order (when re-subscribing).