### PR TITLE
alters response json on subscription scheme change

### DIFF
--- a/assets/js/wcs-att-cart.js
+++ b/assets/js/wcs-att-cart.js
@@ -52,7 +52,8 @@ jQuery( function( $ ) {
 				$cart_totals.replaceWith( $html_totals );
 				$cart_table.replaceWith( $html_table );
 
-				$cart_wrapper.trigger( 'wcsatt_updated_cart' );
+        $cart_wrapper.trigger('wcsatt_updated_cart')
+        $('body').trigger('wcsatt_updated_subscription_scheme', [response])
 
 			} else {
 

--- a/includes/display/class-wcs-att-display-ajax.php
+++ b/includes/display/class-wcs-att-display-ajax.php
@@ -97,10 +97,12 @@ class WCS_ATT_Display_Ajax {
 
 		$html = ob_get_clean();
 
-		wp_send_json( array(
-			'result' => 'success',
-			'html'   => $html
-		) );
+		wp_send_json( apply_filters( 'wcsatt_updated_subscription_scheme_success', [
+			'result'     => 'success',
+			'html'       => $html,
+			'old_scheme' => $current_scheme_key,
+			'new_scheme' => $posted_subscription_scheme_key,
+		], $current_scheme_key, $posted_subscription_scheme_key ) );
 	}
 }
 


### PR DESCRIPTION
This adds the possibility to alter the json object returned when the subscription scheme is changed in the cart. Also, triggers an event on the body element when the response is successful.

I needed this to display custom notices when the subscription scheme changes and some criteria where met.